### PR TITLE
Add menu picker form widget

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -108,7 +108,8 @@ class Plugin extends PluginBase
     public function registerFormWidgets()
     {
         return [
-            'RainLab\Pages\FormWidgets\PagePicker' => 'staticpagepicker'
+            FormWidgets\PagePicker::class => 'staticpagepicker',
+            FormWidgets\MenuPicker::class => 'staticmenupicker',
         ];
     }
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -105,6 +105,15 @@ If you need to select from a list of static pages in your own backend forms, you
 
 The field's assigned value will be the static page's file name, which can be used to link to the page as described above.
 
+If you need to select from a list of static menus in your own backend forms, you can use the `staticmenupicker` widget:
+
+    fields:
+        field_name:
+            label: Static Menu
+            type: staticmenupicker
+
+The field's assigned value will be the static menu's code, which can be used to link to the menu as described above.
+
 ### Placeholders
 
 [Placeholders](https://octobercms.com/docs/cms/layouts#placeholders) defined in the layout are automatically detected by the Static Pages plugin. The Edit Static Page form displays a tab for each placeholder defined in the layout used by the page. Placeholders are defined in the layout in the usual way:

--- a/formwidgets/MenuPicker.php
+++ b/formwidgets/MenuPicker.php
@@ -1,0 +1,50 @@
+<?php namespace RainLab\Pages\FormWidgets;
+
+use Backend\Classes\FormWidgetBase;
+use Cms\Classes\Theme;
+use RainLab\Pages\Classes\Menu;
+
+/**
+ * Static Menu picker widget
+ *
+ * @package RainLab\Pages\FormWidgets
+ */
+class MenuPicker extends FormWidgetBase
+{
+    /**
+     * @inheritDoc
+     */
+    public function render()
+    {
+        $this->prepareVars();
+
+        return $this->makePartial('~/modules/backend/widgets/form/partials/_field_dropdown.htm');
+    }
+
+    /**
+     * Prepares the view data
+     */
+    public function prepareVars()
+    {
+        $this->vars['field'] = $this->makeFormField();
+    }
+
+    protected function makeFormField(): \Backend\Classes\FormField
+    {
+        $field = clone $this->formField;
+        $field->type = 'dropdown';
+        $field->options = $this->getOptions();
+
+        return $field;
+    }
+
+    protected function getOptions(): array
+    {
+        return Menu::listInTheme(Theme::getEditTheme(), true)
+            ->mapWithKeys(function ($menu) {
+                return [
+                    $menu->fileName => $menu->name,
+                ];
+            })->toArray();
+    }
+}

--- a/formwidgets/MenuPicker.php
+++ b/formwidgets/MenuPicker.php
@@ -43,7 +43,7 @@ class MenuPicker extends FormWidgetBase
         return Menu::listInTheme(Theme::getEditTheme(), true)
             ->mapWithKeys(function ($menu) {
                 return [
-                    $menu->fileName => $menu->name,
+                    $menu->code => $menu->name,
                 ];
             })->toArray();
     }


### PR DESCRIPTION
This form widget will allow backend forms to be able to show a list of static menus.

This can be useful for things like theme settings which would allow a site editor to be able to pick which menu should be displayed in various locations. For instance, a theme could have a primary menu and a footer menu location and utilizing this field would allow someone like a client to be able to create different menus and decide where they should be displayed within the theme (kind of like WordPress).

